### PR TITLE
Avoid "async void" method

### DIFF
--- a/PrimS.Telnet/Client.cs
+++ b/PrimS.Telnet/Client.cs
@@ -90,7 +90,7 @@ namespace PrimS.Telnet
     /// Writes the line to the server.
     /// </summary>
     /// <param name="command">The command.</param>
-    public async void WriteLine(string command)
+    public async Task WriteLine(string command)
     {
       await this.Write(string.Format("{0}\n", command));
     }


### PR DESCRIPTION
I got a unhandled exception that crashes my program. Even when there was try-catch around Client.WriteLine method. A quick look at Client.WriteLine revealed that return type was "async void", which is bad practice when dealing with async/await states. Changing from "async void" to "async Task" fixed my problem.

Read more:
https://msdn.microsoft.com/en-us/magazine/jj991977.aspx
