### PR TITLE
Added a LineTerminator property 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ PrimS.Telnet.solution-user.settings.xml
 *.suo
 *.dg
 /PrimS.Telnet.NetStandard/project.lock.json
+/.vs/PrimS.Telnet/v15/Server/sqlite3

--- a/PrimS.Telnet.35.CiTests/WithClient.cs
+++ b/PrimS.Telnet.35.CiTests/WithClient.cs
@@ -156,7 +156,7 @@
           client.WriteLine("username");
           client.TerminatedRead("Password:", TimeSpan.FromMilliseconds(TimeoutMs));
           client.WriteLine("password");
-          client.TerminatedRead(">", TimeSpan.FromMilliseconds(TimeoutMs));
+          client.TerminatedRead(client.LineTerminator, TimeSpan.FromMilliseconds(TimeoutMs));
         }
       }
     }
@@ -171,8 +171,8 @@
           Assert.AreEqual(client.IsConnected, true);
           Assert.AreEqual(client.TryLogin("username", "password", TimeoutMs), true);
           client.WriteLine("show statistic wan2");
-          string s = client.TerminatedRead(">", TimeSpan.FromMilliseconds(TimeoutMs));
-          Assert.IsTrue(s.Contains(">"));
+          string s = client.TerminatedRead(client.LineTerminator, TimeSpan.FromMilliseconds(TimeoutMs));
+          Assert.IsTrue(s.Contains(client.LineTerminator));
           Assert.IsTrue(s.Contains("WAN2"));
         }
       }

--- a/PrimS.Telnet.40.CiTests/WithClient.cs
+++ b/PrimS.Telnet.40.CiTests/WithClient.cs
@@ -78,7 +78,7 @@
           client.WriteLine("username");
           client.TerminatedRead("Password:", TimeSpan.FromMilliseconds(TimeoutMs));
           client.WriteLine("password");
-          client.TerminatedRead(">", TimeSpan.FromMilliseconds(TimeoutMs));
+          client.TerminatedRead(client.LineTerminator, TimeSpan.FromMilliseconds(TimeoutMs));
         }
       }
     }
@@ -93,8 +93,8 @@
           client.IsConnected.Should().Be(true);
           (client.TryLogin("username", "password", TimeoutMs)).Should().Be(true);
           client.WriteLine("show statistic wan2");
-          string s = client.TerminatedRead(">", TimeSpan.FromMilliseconds(TimeoutMs));
-          s.Should().Contain(">");
+          string s = client.TerminatedRead(client.LineTerminator, TimeSpan.FromMilliseconds(TimeoutMs));
+          s.Should().Contain(client.LineTerminator);
           s.Should().Contain("WAN2");
         }
       }

--- a/PrimS.Telnet.40/Client.cs
+++ b/PrimS.Telnet.40/Client.cs
@@ -11,6 +11,11 @@ namespace PrimS.Telnet
   public partial class Client : BaseClient
   {
     /// <summary>
+    /// Expose the internally used line terminator character.
+    /// </summary>
+    public string LineTerminator { get; set; } = ">";
+
+    /// <summary>
     /// Tries to login.
     /// </summary>
     /// <param name="userName">The user name.</param>
@@ -29,7 +34,7 @@ namespace PrimS.Telnet
             this.WriteLine(password);
           }
 
-          return this.IsTerminatedWith(loginTimeOutMs, ">");
+          return this.IsTerminatedWith(loginTimeOutMs, LineTerminator);
         }
       }
       catch (Exception)

--- a/PrimS.Telnet.CiTests/WithClient.cs
+++ b/PrimS.Telnet.CiTests/WithClient.cs
@@ -1,14 +1,13 @@
 ﻿namespace PrimS.Telnet.CiTests
 {
-  using System;
-  using System.Linq;
-  using Microsoft.VisualStudio.TestTools.UnitTesting;
-  using FluentAssertions;
-  using System.Threading.Tasks;
-  using System.Text.RegularExpressions;
-  using System.Diagnostics.CodeAnalysis;
+    using System;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using FluentAssertions;
+    using System.Threading.Tasks;
+    using System.Text.RegularExpressions;
+    using System.Diagnostics.CodeAnalysis;
 
-  [ExcludeFromCodeCoverage]
+    [ExcludeFromCodeCoverage]
   [TestClass]
   public class WithClient
   {
@@ -82,7 +81,7 @@
           await client.WriteLine("username");
           await client.TerminatedReadAsync("Password:", TimeSpan.FromMilliseconds(TimeoutMs));
           await client.WriteLine("password");
-          await client.TerminatedReadAsync(">", TimeSpan.FromMilliseconds(TimeoutMs));
+          await client.TerminatedReadAsync(client.LineTerminator, TimeSpan.FromMilliseconds(TimeoutMs));
         }
       }
     }
@@ -97,8 +96,8 @@
           client.IsConnected.Should().Be(true);
           (await client.TryLoginAsync("username", "password", 1500)).Should().Be(true);
           await client.WriteLine("show statistic wan2");
-          string s = await client.TerminatedReadAsync(">", TimeSpan.FromMilliseconds(TimeoutMs));
-          s.Should().Contain(">");
+          string s = await client.TerminatedReadAsync(client.LineTerminator, TimeSpan.FromMilliseconds(TimeoutMs));
+          s.Should().Contain(client.LineTerminator);
           s.Should().Contain("WAN2");
         }
       }
@@ -115,7 +114,7 @@
           (await client.TryLoginAsync("username", "password", 1500)).Should().Be(true);
           await client.WriteLine("show statistic wan2");
           string s = await client.TerminatedReadAsync(new Regex(".*>$"), TimeSpan.FromMilliseconds(TimeoutMs));
-          s.Should().Contain(">");
+          s.Should().Contain(client.LineTerminator);
           s.Should().Contain("WAN2");
         }
       }
@@ -144,8 +143,8 @@
           client.IsConnected.Should().Be(true);
           (await client.TryLoginAsync("username", "password", TimeoutMs)).Should().Be(true);
           await client.WriteLine("show statistic wan2");
-          string s = await client.TerminatedReadAsync(">", TimeSpan.FromMilliseconds(TimeoutMs));
-          s.Should().Contain(">");
+          string s = await client.TerminatedReadAsync(client.LineTerminator, TimeSpan.FromMilliseconds(TimeoutMs));
+          s.Should().Contain(client.LineTerminator);
           s.Should().Contain("WAN2");
           System.Text.RegularExpressions.Regex regEx = new System.Text.RegularExpressions.Regex("(?!WAN2 total TX: )([0-9.]*)(?! GB ,RX: )([0-9.]*)(?= GB)");
           regEx.IsMatch(s).Should().Be(true);

--- a/PrimS.Telnet.NetStandard/Client.cs
+++ b/PrimS.Telnet.NetStandard/Client.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace PrimS.Telnet
 {
   using System;
@@ -13,13 +15,14 @@ namespace PrimS.Telnet
   /// </summary>
   public class Client : BaseClient
   {
-    /// <summary>
-    /// Initialises a new instance of the <see cref="Client"/> class.
-    /// </summary>
-    /// <param name="hostName">The hostname to connect to.</param>
-    /// <param name="port">The port to connect to.</param>
-    /// <param name="token">The cancellation token.</param>
-    public Client(string hostName, int port, CancellationToken token)
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="Client"/> class.
+        /// </summary>
+        /// <param name="hostName">The hostname to connect to.</param>
+        /// <param name="port">The port to connect to.</param>
+        /// <param name="token">The cancellation token.</param>
+        public Client(string hostName, int port, CancellationToken token)
       : this(new TcpByteStream(hostName, port), token)
     {
     }
@@ -57,6 +60,11 @@ namespace PrimS.Telnet
         throw new InvalidOperationException("Unable to connect to the host.");
       }
     }
+    
+    /// <summary>
+    /// Expose the internally used line terminator character.
+    /// </summary>
+    public string LineTerminator { get; set; } = ">";
 
     /// <summary>
     /// Tries to login asynchronously.
@@ -70,7 +78,7 @@ namespace PrimS.Telnet
       bool result = await this.TrySendUsernameAndPassword(username, password, loginTimeoutMs);
       if (result)
       {
-        result = await this.IsTerminatedWith(loginTimeoutMs, ">");
+        result = await this.IsTerminatedWith(loginTimeoutMs, LineTerminator);
       }
 
       return result;

--- a/PrimS.Telnet.sln.DotSettings.user
+++ b/PrimS.Telnet.sln.DotSettings.user
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/AssemblyExplorer/XmlDocument/@EntryValue">&lt;AssemblyExplorer&gt;&#xD;
+  &lt;Assembly Path="\\OR-Fileserver\Users\akauffman\My Documents\GitHub\Telnet\packages\FluentAssertions.5.3.0\lib\net45\FluentAssertions.dll" /&gt;&#xD;
+&lt;/AssemblyExplorer&gt;</s:String></wpf:ResourceDictionary>

--- a/PrimS.Telnet/PrimS.Telnet.csproj
+++ b/PrimS.Telnet/PrimS.Telnet.csproj
@@ -34,11 +34,17 @@
     <DocumentationFile>bin\Release\PrimS.Telnet.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FluentAssertions, Version=5.3.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.5.3.0\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
     <Reference Include="LiteGuard, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\LiteGuard.1.1.0\lib\net35\LiteGuard.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/PrimS.Telnet/packages.config
+++ b/PrimS.Telnet/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="FluentAssertions" version="5.3.0" targetFramework="net45" />
   <package id="LiteGuard" version="1.1.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
So that programmers can set the line terminator character to match their environment.

I apologize up front, this is my first pull request ever.  I wanted to match your style but I couldn't find other configurable properties to model my change after. Maybe this belongs somewhere else, or you would implement it differently. 

I created issue #25 for this modification and I am also submitting this pull request as a possible solution. I'm not super familiar or comfortable with this repository so it's possible I missed some things.



