### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ code should be minimal, but be prepared to test thoroughly. Please raise an Issu
 it'll help others with the same problems and we'll see what we can do to accomodate your use cases.
 
 Usage:
-```C# Sync
+```csharp
+    //Sync Example
     namespace PrimS.Telnet.CiTests
     {
       using FluentAssertions;
@@ -60,8 +61,10 @@ Usage:
         }
       }
     }
+```
 
-```C# Async
+```csharp
+    // Async Example
     namespace PrimS.Telnet.CiTests
     {
       using System;
@@ -105,8 +108,10 @@ Usage:
         }
       }
     }
+```
 
-```VB.NET
+```vbnet
+    // VB.NET Example
     Private Async Function RunRemoteScript(commandLine As String) As Task(Of Boolean)
         Using telnet = New Client("HostName", 23, _cancellationSource.Token)
             If Not telnet.IsConnected Then Return False


### PR DESCRIPTION
Just a minor tidy up of the examples to split into 3 separate examples and specify the example by a comment on the first line. 

I thought there was a display error because ```c# was written in between the examples.